### PR TITLE
feat: use integrity field from yarn.lock as sha512 for nix derivation

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,2 +1,0 @@
-oleg@canva.com
-uri@canva.com

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ A tool that makes use of the [Nix] package manager to install [Node.js] dependen
 - Remove the need to be check generated files into a code-base, provides IFD if required
 - Make the generation of the Nix expression pure, so no assumptions are made around missing SHAs, local packages locations, etc
 
+
+### Contributing
+
+```
+yarn
+# do i need a certain nix version?
+# can i run nix-shell to develop in this repo with all deps?
+?.?
+how to run tests?
+```
+
 ### Details
 
 It is implemented as a CLI tool written in JavaScript and as a Nix library that picks up that tool and executes it internally to generate a Nix expression out of the given tuple of `package.json` & `yarn.lock` files in a pure manner as a separate Nix derivation, that then can be imported into the Nix runtime and the generated Nix derivations will be built via the provided Nix library to install Node.js dependencies. 

--- a/lib/print.js
+++ b/lib/print.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const lockfile = require('@yarnpkg/lockfile');
+const lockfile = require('./types');
 const { promises: fs } = require('fs');
 const { strict: assert } = require('assert');
 const parse = require('parse-package-name');
@@ -11,7 +11,7 @@ const semver = require('semver');
 /**
  * @typedef {{
  *  type: 'success' | 'merge' | 'conflict',
- *  object: import('@yarnpkg/lockfile').LockFileObject,
+ *  object: lockfile.LockFileObject,
  * }} YarnLockJSON
  */
 
@@ -157,7 +157,8 @@ class Package {
    *   src: {
    *    type: 'url',
    *    url: string,
-   *    sha1?: string
+   *    sha1?: string,
+   *    sha512?: string
    *   } | {
    *    type: 'local',
    *   },
@@ -201,7 +202,7 @@ class Package {
   static create(
     pkgInfo,
     // @ts-ignore because there is no optionalDependencies in the type
-    { version, resolved, dependencies = {}, optionalDependencies = {} }
+    { version, integrity, resolved, dependencies = {}, optionalDependencies = {} }
   ) {
     const { scope = '', name } = Id.parse(pkgInfo.name);
 
@@ -211,11 +212,17 @@ class Package {
       const parsedUrl = new URL(resolved);
       // prettier-ignore
       if (['registry.yarnpkg.com', 'registry.npmjs.org'].includes(parsedUrl.host)) {
-        src = { 
-          sha1: parsedUrl.hash.slice(1), // cut off the first ('#') character
+        const sha1 = parsedUrl.hash.slice(1);
+        const sha512 = integrity;
+        src = {
           url: parsedUrl.origin + parsedUrl.pathname, 
           type: 'url',
         };
+        if (sha512 != '') {
+          src.sha512 = sha512;
+        } else if (sha1 != '') {
+          src.sha1 = sha1;
+        }
       } else {
         src = { 
           sha1: undefined, // We don't provide sha in order to force to override it manually
@@ -306,7 +313,7 @@ class Package {
   renderSrc() {
     switch (this.src.type) {
       case 'url':
-        const { url, sha1 } = this.src;
+        const { url, sha1, sha512 } = this.src;
         // Some of the urls can look like "https://codeload.github.com/xolvio/cucumber-js/tar.gz/cf953cb5b5de30dbcc279f59e4ebff3aa040071c",
         // i.e. no extention given. That's why Nix unable to recognize the type of archive so we need to have
         // name specified explicitly to all Nix to infer the archive type.
@@ -340,9 +347,8 @@ class Package {
         } 
       url = "${url}"; 
       ${
-        sha1
-          ? `sha1 = "${sha1}"`
-          : `sha256 = abort ''
+        // TODO: Fallback to sha1 if we dont have sha512/integrity
+        sha512 ? `sha512 = "${sha512}"` : `sha512 = abort ''
         
         
         Failed to infer \`sha256\` hash of the \`${this.renderKey()}\` package source from

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,35 @@
+// Type definitions for @yarnpkg/lockfile 1.1
+// Project: https://github.com/yarnpkg/yarn/tree/master/packages/lockfile
+// Definitions by: Eric Wang <https://github.com/fa93hws>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface Dependency {
+    [packageName: string]: string;
+  }
+  
+  export interface FirstLevelDependency {
+    version: string;
+    resolved?: string | undefined;
+    integrity?: string | undefined;
+    dependencies?: Dependency | undefined;
+  }
+  
+  export interface LockFileObject {
+    [packageName: string]: FirstLevelDependency;
+  }
+  
+  // @ts-ignore
+  export function parse(
+    file: string,
+    fileLoc?: string,
+  ): {
+    type: 'success' | 'merge' | 'conflict';
+    object: any;
+  };
+  
+  // @ts-ignore
+  export function stringify(
+    json: any,
+    noHeader?: boolean,
+    enableVersions?: boolean,
+  ): string;


### PR DESCRIPTION
Newer yarn versions don't have the sha1 in their url with a `#`, so fails for some users.

But I notice _most_ lockfiles have an `integrity` field. See https://github.com/canva-public/js2nix/blob/main/yarn.lock#L8